### PR TITLE
fix(workflows): correct nuget push command option

### DIFF
--- a/.github/workflows/publish-nuget-packages.yaml
+++ b/.github/workflows/publish-nuget-packages.yaml
@@ -38,4 +38,4 @@ jobs:
         run: dotnet pack src/building-blocks/FinnHub.Shared.Kernel/FinnHub.Shared.Kernel.csproj --configuration Release --output ./nupkgs
 
       - name: Push packages to NuGet.org
-        run: dotnet nuget push "./nupkgs/*.nupkg" -k ${{ secrets.NUGET_API_KEY }} --s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "./nupkgs/*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
- Changed the `--s` option to `-s` in the dotnet nuget push command to use the correct short form for the source option.
- Ensured the command is properly formatted for successful execution.