### PR TITLE
feat(docker): expose port 8081 and update project references

### DIFF
--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Dockerfile
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Dockerfile
@@ -8,9 +8,6 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
-COPY ["../../../building-blocks/FinnHub.Shared.Core/FinnHub.Shared.Core.csproj", "FinnHub.Shared.Core/"]
-COPY ["../../../building-blocks/FinnHub.Shared.Kernel/FinnHub.Shared.Kernel.csproj", "FinnHub.Shared.Kernel/"]
-COPY ["../../../building-blocks/FinnHub.Shared.Infrastructure/FinnHub.Shared.Infrastructure.csproj", "FinnHub.Shared.Infrastructure/"]
 COPY ["src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj", "FinnHub.MarketData.WebApi/"]
 
 RUN dotnet restore "FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj"

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj
@@ -10,6 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FinnHub.Shared.Core" Version="1.0.0" />
+    <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
+    <PackageReference Include="FinnHub.Shared.Kernel" Version="1.0.0" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
@@ -24,13 +27,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.4.22" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Core\FinnHub.Shared.Core.csproj" />
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Kernel\FinnHub.Shared.Kernel.csproj" />
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Infrastructure\FinnHub.Shared.Infrastructure.csproj" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Domain/FinnHub.PortfolioManagement.Domain.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Domain/FinnHub.PortfolioManagement.Domain.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Kernel\FinnHub.Shared.Kernel.csproj" />
+    <PackageReference Include="FinnHub.Shared.Kernel" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/FinnHub.PortfolioManagement.Infrastructure.Authentication.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/FinnHub.PortfolioManagement.Infrastructure.Authentication.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.12.0" />
   </ItemGroup>
 
   <ItemGroup>
       <ProjectReference Include="..\FinnHub.PortfolioManagement.Application\FinnHub.PortfolioManagement.Application.csproj" />
-      <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Infrastructure\FinnHub.Shared.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Caching/FinnHub.PortfolioManagement.Infrastructure.Caching.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Caching/FinnHub.PortfolioManagement.Infrastructure.Caching.csproj
@@ -7,14 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.6.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.6" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Infrastructure\FinnHub.Shared.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Messaging/FinnHub.PortfolioManagement.Infrastructure.Messaging.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Messaging/FinnHub.PortfolioManagement.Infrastructure.Messaging.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
@@ -17,7 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Domain\FinnHub.PortfolioManagement.Domain.csproj" />
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Infrastructure\FinnHub.Shared.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/FinnHub.PortfolioManagement.Infrastructure.Persistence.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/FinnHub.PortfolioManagement.Infrastructure.Persistence.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+    <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
@@ -17,7 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Application\FinnHub.PortfolioManagement.Application.csproj" />
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Messaging\FinnHub.PortfolioManagement.Infrastructure.Messaging.csproj" />
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Infrastructure\FinnHub.Shared.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Telemetry/FinnHub.PortfolioManagement.Infrastructure.Telemetry.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Telemetry/FinnHub.PortfolioManagement.Infrastructure.Telemetry.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
@@ -16,10 +17,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-     <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Infrastructure\FinnHub.Shared.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Dockerfile
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Dockerfile
@@ -8,9 +8,6 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
-COPY ["../../../building-blocks/FinnHub.Shared.Core/FinnHub.Shared.Core.csproj", "FinnHub.Shared.Core/"]
-COPY ["../../../building-blocks/FinnHub.Shared.Kernel/FinnHub.Shared.Kernel.csproj", "FinnHub.Shared.Kernel/"]
-COPY ["../../../building-blocks/FinnHub.Shared.Infrastructure/FinnHub.Shared.Infrastructure.csproj", "FinnHub.Shared.Infrastructure/"]
 COPY ["src/FinnHub.PortfolioManagement.WebApi/FinnHub.PortfolioManagement.WebApi.csproj", "FinnHub.PortfolioManagement.WebApi/"]
 COPY ["src/FinnHub.PortfolioManagement.Application/FinnHub.PortfolioManagement.Application.csproj", "FinnHub.PortfolioManagement.Application/"]
 COPY ["src/FinnHub.PortfolioManagement.Domain/FinnHub.PortfolioManagement.Domain.csproj", "FinnHub.PortfolioManagement.Domain/"]

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/FinnHub.PortfolioManagement.WebApi.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/FinnHub.PortfolioManagement.WebApi.csproj
@@ -22,7 +22,6 @@
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Authentication\FinnHub.PortfolioManagement.Infrastructure.Authentication.csproj" />
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Persistence\FinnHub.PortfolioManagement.Infrastructure.Persistence.csproj" />
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Telemetry\FinnHub.PortfolioManagement.Infrastructure.Telemetry.csproj" />
-    <ProjectReference Include="..\..\..\..\building-blocks\FinnHub.Shared.Core\FinnHub.Shared.Core.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated Dockerfile to expose port 8081 for incoming traffic.
- Replaced project references with package references for:
  - `FinnHub.Shared.Core`, `FinnHub.Shared.Kernel`, and `FinnHub.Shared.Infrastructure` (version `1.0.0`).
  - Updated `Scalar.AspNetCore` package from version `2.4.22` to `2.5.0`.
- Removed project references to building blocks, streamlining the project structure.
- Changes reflected across multiple `.csproj` files in the `FinnHub.PortfolioManagement` solution.