### PR TITLE
feat(market-data): add watchlist event handling for data ingestion an…

### DIFF
--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Assets/Commands/CreateAsset/CreateAssetEndpoint.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Assets/Commands/CreateAsset/CreateAssetEndpoint.cs
@@ -14,7 +14,7 @@ internal sealed class CreateAssetEndpoint : IEndpoint
 
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost("/assets", async (Request request, CreateAssetHandler handler, CancellationToken cancellationToken) =>
+        app.MapPost("/api/v1/assets", async (Request request, CreateAssetHandler handler, CancellationToken cancellationToken) =>
         {
             var command = new CreateAssetCommand
             {
@@ -26,6 +26,9 @@ internal sealed class CreateAssetEndpoint : IEndpoint
             var result = await handler.Handle(command, cancellationToken);
 
             return result.Match(Results.Created, CustomResults.Problem);
-        });
+        })
+            .RequireAuthorization()
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
     }
 }

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Assets/Domain/Events/AssetWatchlistChangedEvent.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Assets/Domain/Events/AssetWatchlistChangedEvent.cs
@@ -1,12 +1,10 @@
-﻿using FinnHub.MarketData.WebApi.Features.Assets.Domain.Enums;
-
-namespace FinnHub.MarketData.WebApi.Features.Assets.Domain.Events;
+﻿namespace FinnHub.MarketData.WebApi.Features.Assets.Domain.Events;
 
 public sealed record AssetWatchlistChangedEvent(
     Guid Id,
     string Exchange,
-    AssetChangedType Action,
+    string Action,
     string Symbol,
-    AssetType AssetType,
+    string AssetType,
     DateTimeOffset OccurredOn
 );

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Commands/SaveMarketData/SaveMarketDataCommand.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Commands/SaveMarketData/SaveMarketDataCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace FinnHub.MarketData.WebApi.Features.Quotes.Commands.IngestMarketData;
+﻿namespace FinnHub.MarketData.WebApi.Features.Quotes.Commands.SaveMarketData;
 
 public sealed record SaveMarketDataCommand(
     string Symbol,

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Commands/SaveMarketData/SaveMarketDataHandler.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Commands/SaveMarketData/SaveMarketDataHandler.cs
@@ -1,5 +1,4 @@
-﻿using FinnHub.MarketData.WebApi.Features.Quotes.Commands.IngestMarketData;
-using FinnHub.MarketData.WebApi.Features.Quotes.Domain.Entities;
+﻿using FinnHub.MarketData.WebApi.Features.Quotes.Domain.Entities;
 using FinnHub.MarketData.WebApi.Features.Quotes.Domain.Repositories;
 using FinnHub.Shared.Core;
 
@@ -16,7 +15,7 @@ internal sealed class SaveMarketDataHandler(IQuoteRepository quoteRepository)
             command.HighPrice,
             command.LowPrice,
             command.LastPrice,
-            (long)command.Volume,
+            command.Volume,
             "1s"
         );
 

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Domain/Entities/HistoricalQuote.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Domain/Entities/HistoricalQuote.cs
@@ -10,7 +10,7 @@ public sealed class HistoricalQuote : Entity
     public decimal High { get; private set; }
     public decimal Low { get; private set; }
     public decimal Close { get; private set; }
-    public long Volume { get; private set; }
+    public decimal Volume { get; private set; }
     public string Interval { get; private set; }
     public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
 
@@ -21,7 +21,7 @@ public sealed class HistoricalQuote : Entity
         decimal high,
         decimal low,
         decimal close,
-        long volume,
+        decimal volume,
         string interval
     )
     {

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Infrastructure/Binance/Models/CombinedStreamModel.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Infrastructure/Binance/Models/CombinedStreamModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace FinnHub.MarketData.WebApi.Features.Quotes.Infrastructure.Binance.Models;
+
+internal sealed record CombinedStreamModel<T>
+{
+    [JsonPropertyName("stream")]
+    public required string Stream { get; init; } = string.Empty;
+
+    [JsonPropertyName("data")]
+    public required T Data { get; init; } = default!;
+}

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Infrastructure/Sync/DataIngestionSyncService.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Infrastructure/Sync/DataIngestionSyncService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 
-using FinnHub.MarketData.WebApi.Features.Quotes.Commands.IngestMarketData;
 using FinnHub.MarketData.WebApi.Features.Quotes.Commands.SaveMarketData;
 using FinnHub.MarketData.WebApi.Features.Quotes.Domain.Events;
 using FinnHub.MarketData.WebApi.Shared.Infrastructure.Messaging.Services;

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj
@@ -30,4 +30,8 @@
     <PackageReference Include="Scalar.AspNetCore" Version="2.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Features\Quotes\Infrastructure\Consumer\" />
+  </ItemGroup>
+
 </Project>

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj
@@ -30,8 +30,4 @@
     <PackageReference Include="Scalar.AspNetCore" Version="2.5.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Features\Quotes\Infrastructure\Consumer\" />
-  </ItemGroup>
-
 </Project>

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/appsettings.Development.json
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/appsettings.Development.json
@@ -20,7 +20,7 @@
     "ServiceVersion": "1.0.0"
   },
   "BinanceSettings": {
-    "Uri": "wss://stream.binance.com:9443/ws/"
+    "Uri": "wss://stream.binance.com:9443/"
   },
   "MessagingSettings": {
     "ConnectionString": "amqp://guest:guest@localhost:5672",


### PR DESCRIPTION
…d update api endpoints

- Change API route for `CreateAssetEndpoint` to `/api/v1/assets` and add authorization and response type configurations.
- Add `IMessageBus` dependency to `CreateAssetHandler` for publishing `AssetWatchlistChangedEvent`.
- Modify `AssetWatchlistChangedEvent` to use strings for `Action` and `AssetType` properties.
- Rename `SaveMarketDataCommand` namespace for clarity.
- Change `Volume` property type from `long` to `decimal` in `SaveMarketDataHandler`.
- Enhance `BinanceDataIngestionService` with methods for managing asset watchlist changes.
- Introduce `CombinedStreamModel<T>` for better deserialization of Binance WebSocket messages.
- Update project structure to include a new folder for quotes infrastructure features.
- Modify `appsettings.Development.json` to correct the Binance WebSocket URI.