### PR TITLE
feat(integrations): add market data and caching services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
       - POSTGRESQL_PASSWORD=postgres
     volumes:
       - postgresql_data:/bitnami/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
 
   finnhub.nosqldb:
     image: bitnami/mongodb:latest
@@ -23,6 +25,11 @@ services:
       - MONGODB_DATABASE=finnhub_db
     volumes:
       - mongodb_data:/bitnami/mongodb
+    healthcheck:
+      test: ["CMD", "mongo", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   finnhub.rabbitmq:
     image: rabbitmq:4-management
@@ -35,6 +42,22 @@ services:
       - RABBITMQ_DEFAULT_PASS=guest
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  finnhub.redis:
+    image: bitnami/redis:latest
+    container_name: finnhub.redis
+    ports:
+      - "6379:6379"
+    environment:
+      - REDIS_PASSWORD=redis123
+      - REDIS_AOF_ENABLED=yes
+    volumes:
+      - redis_data:/bitnami/redis/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -76,3 +99,4 @@ services:
 volumes:
   mongodb_data:
   postgresql_data:
+  redis_data:

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Assets/Commands/CreateAsset/CreateAssetEndpoint.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Assets/Commands/CreateAsset/CreateAssetEndpoint.cs
@@ -29,6 +29,7 @@ internal sealed class CreateAssetEndpoint : IEndpoint
         })
             .RequireAuthorization()
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
-            .ProducesProblem(StatusCodes.Status400BadRequest);
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .WithTags(EndpointTags.Assets);
     }
 }

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Queries/GetLatestPrice/GetLatestPriceEndpoint.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Features/Quotes/Queries/GetLatestPrice/GetLatestPriceEndpoint.cs
@@ -1,0 +1,33 @@
+﻿using FinnHub.MarketData.WebApi.Features.Quotes.Domain.Repositories;
+using FinnHub.MarketData.WebApi.Shared.Presentation.Endpoints;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinnHub.MarketData.WebApi.Features.Quotes.Queries.GetLatestPrice;
+
+public class GetLatestPriceEndpoint : IEndpoint
+{
+    internal sealed record Response(decimal CurrentPrice);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+            "api/v1/quotes/{assetSymbol}/current-price",
+            async (
+                [FromRoute] string assetSymbol,
+                [FromServices] IQuoteRepository quoteRepository,
+                CancellationToken cancellationToken
+            ) =>
+            {
+                var latestQuote = await quoteRepository.GetLatestBySymbolAsync(assetSymbol, cancellationToken);
+
+                return latestQuote is null
+                    ? Results.NotFound()
+                    : Results.Ok(new Response(latestQuote.Close));
+            })
+            .RequireAuthorization()
+            .Produces<Response>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithTags(EndpointTags.Quotes);
+    }
+}

--- a/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Shared/Presentation/Endpoints/EndpointTags.cs
+++ b/src/contexts/market-data/src/FinnHub.MarketData.WebApi/Shared/Presentation/Endpoints/EndpointTags.cs
@@ -1,0 +1,7 @@
+﻿namespace FinnHub.MarketData.WebApi.Shared.Presentation.Endpoints;
+
+public static class EndpointTags
+{
+    public const string Assets = "Assets";
+    public const string Quotes = "Quotes";
+}

--- a/src/contexts/portfolio-management/FinnHub.PortfolioManagement.sln
+++ b/src/contexts/portfolio-management/FinnHub.PortfolioManagement.sln
@@ -35,6 +35,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinnHub.PortfolioManagement
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinnHub.PortfolioManagement.Infrastructure.Telemetry", "src\FinnHub.PortfolioManagement.Infrastructure.Telemetry\FinnHub.PortfolioManagement.Infrastructure.Telemetry.csproj", "{CF5A1104-77D3-9D4E-0229-9B4FB855494B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinnHub.PortfolioManagement.Infrastructure.Integrations", "src\FinnHub.PortfolioManagement.Infrastructure.Integrations\FinnHub.PortfolioManagement.Infrastructure.Integrations.csproj", "{1B40B0E0-4179-4441-8D88-E6F9F315EB39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +87,10 @@ Global
 		{CF5A1104-77D3-9D4E-0229-9B4FB855494B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF5A1104-77D3-9D4E-0229-9B4FB855494B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF5A1104-77D3-9D4E-0229-9B4FB855494B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B40B0E0-4179-4441-8D88-E6F9F315EB39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B40B0E0-4179-4441-8D88-E6F9F315EB39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B40B0E0-4179-4441-8D88-E6F9F315EB39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B40B0E0-4179-4441-8D88-E6F9F315EB39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -101,6 +107,7 @@ Global
 		{2FE74A99-AF28-4603-B5B3-DD7A8691EFC4} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{6C7860BA-35E4-4A7C-AC46-85E07AEFED63} = {7E3C9E67-D09E-43D7-B88C-1754FB0B3A83}
 		{CF5A1104-77D3-9D4E-0229-9B4FB855494B} = {7E3C9E67-D09E-43D7-B88C-1754FB0B3A83}
+		{1B40B0E0-4179-4441-8D88-E6F9F315EB39} = {7E3C9E67-D09E-43D7-B88C-1754FB0B3A83}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {77EDBFBC-F0EF-4D34-9EC4-AC85A96374D9}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/MarketData/IMarketDataService.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/MarketData/IMarketDataService.cs
@@ -1,0 +1,5 @@
+﻿namespace FinnHub.PortfolioManagement.Application.Abstractions.MarketData;
+public interface IMarketDataService
+{
+    Task<decimal> GetCurrentMarketValueAsync(string assetSymbol, CancellationToken cancellationToken);
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/Tokens/ITokenService.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/Tokens/ITokenService.cs
@@ -1,0 +1,6 @@
+﻿namespace FinnHub.PortfolioManagement.Application.Abstractions.Tokens;
+
+public interface ITokenService
+{
+    public Task<string> GetAccessToken();
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Commands/RegisterBuyAsset/RegisterBuyAssetHandler.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Commands/RegisterBuyAsset/RegisterBuyAssetHandler.cs
@@ -1,4 +1,5 @@
 ﻿using FinnHub.PortfolioManagement.Application.Abstractions;
+using FinnHub.PortfolioManagement.Application.Abstractions.MarketData;
 using FinnHub.PortfolioManagement.Application.Abstractions.Users;
 using FinnHub.PortfolioManagement.Application.Errors;
 using FinnHub.PortfolioManagement.Domain.Aggregates.Repositories;
@@ -12,7 +13,8 @@ namespace FinnHub.PortfolioManagement.Application.Commands.RegisterBuyAsset;
 internal sealed class RegisterBuyAssetHandler(
     IPortfolioRepository portfolioRepository,
     IUnitOfWork unitOfWork,
-    IUserContext userContext
+    IUserContext userContext,
+    IMarketDataService marketDataService
 ) : IRequestHandler<RegisterBuyAssetRequest, Result<RegisterBuyAssetResponse>>
 {
     public async Task<Result<RegisterBuyAssetResponse>> Handle(RegisterBuyAssetRequest request, CancellationToken cancellationToken)
@@ -26,8 +28,7 @@ internal sealed class RegisterBuyAssetHandler(
         if (portfolio is null)
             return Result.Failure<RegisterBuyAssetResponse>(PortfolioErrors.PortfolioNotFound);
 
-        // TODO: Implement logic to call market data service to get the current market value of the asset
-        var currentMarketValue = 0;
+        var currentMarketValue = await marketDataService.GetCurrentMarketValueAsync(request.AssetSymbol, cancellationToken);
 
         var transaction = portfolio.BuyAsset(
               request.AssetSymbol,

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/FinnHub.PortfolioManagement.Infrastructure.Authentication.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/FinnHub.PortfolioManagement.Infrastructure.Authentication.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
       <ProjectReference Include="..\FinnHub.PortfolioManagement.Application\FinnHub.PortfolioManagement.Application.csproj" />
+      <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Caching\FinnHub.PortfolioManagement.Infrastructure.Caching.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/Services/TokenService.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/Services/TokenService.cs
@@ -1,0 +1,54 @@
+﻿using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+using FinnHub.PortfolioManagement.Application.Abstractions.Tokens;
+using FinnHub.PortfolioManagement.Application.Abstractions.Users;
+using FinnHub.PortfolioManagement.Infrastructure.Authentication.Settings;
+using FinnHub.PortfolioManagement.Infrastructure.Caching.Abstractions;
+
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FinnHub.PortfolioManagement.Infrastructure.Authentication.Services;
+
+internal class TokenService(
+    IUserContext userContext,
+    IOptions<AuthenticationSettings> options,
+    ICacheService cacheService
+) : ITokenService
+{
+    private readonly AuthenticationSettings _settings = options.Value;
+    public async Task<string> GetAccessToken()
+    {
+        var cacheKey = $"AccessToken:{userContext.UserId}";
+
+        var accessToken = await cacheService.GetOrCreateAsync(
+            key: cacheKey,
+            factory: _ => ValueTask.FromResult(GenerateToken(userContext.UserId)),
+            expiration: TimeSpan.FromHours(_settings.JwtExpiration) - TimeSpan.FromMinutes(5)
+        );
+
+        return accessToken;
+    }
+
+    private string GenerateToken(Guid userId)
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(_settings.JwtSecret));
+        var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
+
+        var token = new JwtSecurityToken(
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(_settings.JwtExpiration),
+            signingCredentials: credentials
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/Settings/AuthenticationSettings.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/Settings/AuthenticationSettings.cs
@@ -9,5 +9,5 @@ internal sealed record AuthenticationSettings
     public required string JwtSecret { get; init; }
 
     [Required]
-    public TimeSpan JwtExpiration { get; init; }
+    public int JwtExpiration { get; init; }
 }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/Setup/DependencyInjectionConfiguration.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Authentication/Setup/DependencyInjectionConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 
+using FinnHub.PortfolioManagement.Application.Abstractions.Tokens;
 using FinnHub.PortfolioManagement.Application.Abstractions.Users;
 using FinnHub.PortfolioManagement.Infrastructure.Authentication.Services;
 using FinnHub.PortfolioManagement.Infrastructure.Authentication.Settings;
@@ -23,6 +24,7 @@ public static class DependencyInjectionConfiguration
         services.AddJwtAuthentication(settings);
 
         services.AddScoped<IUserContext, UserContextService>();
+        services.AddScoped<ITokenService, TokenService>();
 
         return services;
     }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Caching/Setup/DependencyInjectionConfiguration.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Caching/Setup/DependencyInjectionConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using FinnHub.PortfolioManagement.Infrastructure.Caching.Settings;
+﻿using FinnHub.PortfolioManagement.Infrastructure.Caching.Abstractions;
+using FinnHub.PortfolioManagement.Infrastructure.Caching.Services;
+using FinnHub.PortfolioManagement.Infrastructure.Caching.Settings;
 using FinnHub.Shared.Infrastructure.Extensions;
 
 using Microsoft.Extensions.Caching.Hybrid;
@@ -13,19 +15,19 @@ public static class DependencyInjectionConfiguration
     {
         var settings = services.GetAndConfigureSettings<CacheSettings>(configuration, CacheSettings.SectionName);
 
-        services.AddHybridCache(options =>
+        services.AddHybridCache(options => options.DefaultEntryOptions = new HybridCacheEntryOptions
         {
-            options.DefaultEntryOptions = new HybridCacheEntryOptions
-            {
-                LocalCacheExpiration = TimeSpan.FromMinutes(settings.DefaultExpirationInMinutes),
-                Expiration = TimeSpan.FromMinutes(settings.DefaultExpirationInMinutes)
-            };
+            LocalCacheExpiration = TimeSpan.FromMinutes(settings.DefaultExpirationInMinutes),
+            Expiration = TimeSpan.FromMinutes(settings.DefaultExpirationInMinutes)
         });
         services.AddStackExchangeRedisCache(options =>
         {
             options.Configuration = settings.ConnectionString;
             options.InstanceName = settings.CacheName;
         });
+
+        services.AddScoped<ICacheService, HybridCacheService>();
+
         return services;
     }
 }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/FinnHub.PortfolioManagement.Infrastructure.Integrations.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/FinnHub.PortfolioManagement.Infrastructure.Integrations.csproj
@@ -8,6 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
+    <PackageReference Include="Flurl" Version="4.0.0" />
+    <PackageReference Include="Flurl.Http" Version="4.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinnHub.PortfolioManagement.Application\FinnHub.PortfolioManagement.Application.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/MarketDataService.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/MarketDataService.cs
@@ -1,0 +1,37 @@
+﻿using FinnHub.PortfolioManagement.Application.Abstractions.MarketData;
+using FinnHub.PortfolioManagement.Application.Abstractions.Tokens;
+using FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData.Models;
+using FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData.Settings;
+
+using Flurl;
+using Flurl.Http;
+
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData;
+
+internal sealed class MarketDataService(
+    IOptions<MarketDataSettings> options,
+    ITokenService tokenService
+) : IMarketDataService
+{
+    private readonly MarketDataSettings _settings = options.Value;
+
+    public async Task<decimal> GetCurrentMarketValueAsync(string assetSymbol, CancellationToken cancellationToken)
+    {
+        // TODO: Add resilience policies.
+        // TODO: Add caching to avoid unnecessary API calls.
+        // TODO: Add authentication
+        var accessToken = await tokenService.GetAccessToken();
+
+        var result = await $"{_settings.BaseUrl}"
+            .AppendPathSegment("api/v1/quotes")
+            .AppendPathSegment(assetSymbol)
+            .AppendPathSegment("current-price")
+            .WithOAuthBearerToken(accessToken)
+            .GetJsonAsync<GetCurrentMarketValueResponse>(cancellationToken: cancellationToken);
+
+        return result.CurrentPrice;
+    }
+
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/Models/GetCurrentMarketValueResponse.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/Models/GetCurrentMarketValueResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData.Models;
+
+internal sealed record class GetCurrentMarketValueResponse
+{
+    public decimal CurrentPrice { get; init; }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/Settings/MarketDataSettings.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/Settings/MarketDataSettings.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData.Settings;
+
+internal sealed record MarketDataSettings
+{
+    public const string SectionName = nameof(MarketDataSettings);
+
+    [Required, Url]
+    public required string BaseUrl { get; init; }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/Setup/MarketDataConfiguration.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Services/MarketData/Setup/MarketDataConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using FinnHub.PortfolioManagement.Application.Abstractions.MarketData;
+using FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData.Settings;
+using FinnHub.Shared.Infrastructure.Extensions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData.Setup;
+
+internal static class MarketDataConfiguration
+{
+    public static IServiceCollection AddMarketDataConfiguration(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.GetAndConfigureSettings<MarketDataSettings>(configuration, MarketDataSettings.SectionName);
+        services.AddScoped<IMarketDataService, MarketDataService>();
+        return services;
+    }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Setup/DependencyInjectionConfiguration.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Setup/DependencyInjectionConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using FinnHub.PortfolioManagement.Infrastructure.Integrations.Services.MarketData.Setup;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FinnHub.PortfolioManagement.Infrastructure.Integrations.Setup;
+public static class DependencyInjectionConfiguration
+{
+    public static IServiceCollection AddIntegrationsConfiguration(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMarketDataConfiguration(configuration);
+
+        return services;
+    }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Repositories/PortfolioRepository.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Repositories/PortfolioRepository.cs
@@ -12,7 +12,6 @@ internal sealed class PortfolioRepository(ApplicationDbContext dbContext) : IPor
 
     public Task<Portfolio?> GetByIdAsync(Guid userId, Guid id, CancellationToken cancellationToken = default)
         => dbContext.Portfolios
-            .AsSplitQuery()
             .Include(x => x.Transactions)
             .Include(x => x.Positions)
             .FirstOrDefaultAsync(p => p.UserId == userId && p.Id == id, cancellationToken);

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Telemetry/Setup/DependencyInjectionConfiguration.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Telemetry/Setup/DependencyInjectionConfiguration.cs
@@ -62,6 +62,7 @@ public static class DependencyInjectionConfiguration
                 .AddSource(settings.ServiceName)
                 .SetResourceBuilder(resourceBuilder)
                 .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
                 .AddNpgsql()
                 .AddEntityFrameworkCoreInstrumentation(cfg => cfg.SetDbStatementForText = true)
                 .AddOtlpExporter(cfg =>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/FinnHub.PortfolioManagement.WebApi.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/FinnHub.PortfolioManagement.WebApi.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Authentication\FinnHub.PortfolioManagement.Infrastructure.Authentication.csproj" />
+    <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Integrations\FinnHub.PortfolioManagement.Infrastructure.Integrations.csproj" />
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Persistence\FinnHub.PortfolioManagement.Infrastructure.Persistence.csproj" />
     <ProjectReference Include="..\FinnHub.PortfolioManagement.Infrastructure.Telemetry\FinnHub.PortfolioManagement.Infrastructure.Telemetry.csproj" />
   </ItemGroup>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Startup.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Startup.cs
@@ -1,5 +1,7 @@
 ﻿using FinnHub.PortfolioManagement.Application.Setup;
 using FinnHub.PortfolioManagement.Infrastructure.Authentication.Setup;
+using FinnHub.PortfolioManagement.Infrastructure.Caching.Setup;
+using FinnHub.PortfolioManagement.Infrastructure.Integrations.Setup;
 using FinnHub.PortfolioManagement.Infrastructure.Persistence.Setup;
 using FinnHub.PortfolioManagement.Infrastructure.Telemetry.Setup;
 using FinnHub.PortfolioManagement.WebApi.Setup;
@@ -16,9 +18,13 @@ public static class StartupHelper
         builder.AddTelemetryConfiguration();
         services.AddPresentationConfiguration();
         services.AddOpenApiConfiguration();
+
+        services.AddApplicationConfiguration();
+
         services.AddPersistenceConfiguration(configuration);
         services.AddAuthenticationConfiguration(configuration);
-        services.AddApplicationConfiguration();
+        services.AddIntegrationsConfiguration(configuration);
+        services.AddCachingConfiguration(configuration);
     }
 
     public static void ConfigureApp(WebApplication app)

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/appsettings.Development.json
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/appsettings.Development.json
@@ -17,5 +17,12 @@
     "OpenTelemetryEndpoint": "http://localhost:8200",
     "ServiceName": "FinnHub.PortfolioManagement",
     "ServiceVersion": "1.0.0"
+  },
+  "CacheSettings": {
+    "ConnectionString": "http://localhost:6379",
+    "CacheName": "FinnHub.PortfolioManagement"
+  },
+  "MarketDataSettings": {
+    "BaseUrl": "https://localhost:7113/"
   }
 }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/appsettings.Test.json
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/appsettings.Test.json
@@ -17,5 +17,12 @@
     "OpenTelemetryEndpoint": "http://localhost:8200",
     "ServiceName": "FinnHub.PortfolioManagement",
     "ServiceVersion": "1.0.0"
+  },
+  "CacheSettings": {
+    "ConnectionString": "http://localhost:6379",
+    "CacheName": "FinnHub.PortfolioManagement"
+  },
+  "MarketDataSettings": {
+    "BaseUrl": "https://localhost:7113/"
   }
 }

--- a/src/contexts/portfolio-management/test/FinnHub.PortfolioManagement.WebApi.Tests/Common/WebApiFactory.cs
+++ b/src/contexts/portfolio-management/test/FinnHub.PortfolioManagement.WebApi.Tests/Common/WebApiFactory.cs
@@ -1,5 +1,6 @@
 ﻿using DotNet.Testcontainers.Builders;
 
+using FinnHub.PortfolioManagement.Application.Abstractions.MarketData;
 using FinnHub.PortfolioManagement.Domain.Aggregates;
 using FinnHub.PortfolioManagement.Infrastructure.Persistence.Context;
 using FinnHub.PortfolioManagement.WebApi.Tests.Common.Aggregates;
@@ -8,9 +9,14 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using NSubstitute;
 
 using Testcontainers.PostgreSql;
+using Testcontainers.Redis;
 
 namespace FinnHub.PortfolioManagement.WebApi.Tests.Common;
 public class WebApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
@@ -24,52 +30,79 @@ public class WebApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
         .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(5432))
         .Build();
 
+    private readonly RedisContainer _redisContainer = new RedisBuilder()
+        .WithImage("redis:latest")
+        .WithPortBinding(6379, true)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(6379))
+        .Build();
+
+    public IMarketDataService MarketDataServiceMock { get; private set; } = Substitute.For<IMarketDataService>();
+    public Portfolio PortfolioMock { get; private set; } = default!;
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Test")
             .ConfigureTestServices(services =>
-        {
-            var descriptor = services.SingleOrDefault(s => s.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
-
-            if (descriptor is not null)
-                services.Remove(descriptor);
-
-            services.AddDbContext<ApplicationDbContext>(options =>
             {
-                options
-                    .UseNpgsql(_dbContainer.GetConnectionString())
-                    .UseSnakeCaseNamingConvention()
-                    .EnableSensitiveDataLogging();
+                #region Database Configuration
+                var descriptor = services.SingleOrDefault(s => s.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+
+                if (descriptor is not null)
+                    services.Remove(descriptor);
+
+                services.AddDbContext<ApplicationDbContext>(options =>
+                {
+                    options
+                        .UseNpgsql(_dbContainer.GetConnectionString())
+                        .UseSnakeCaseNamingConvention()
+                        .EnableSensitiveDataLogging();
+                });
+                #endregion
+
+                #region Cache Configuration
+                services.RemoveAll<HybridCache>();
+                services.AddStackExchangeRedisCache(options =>
+                {
+                    options.Configuration = _redisContainer.GetConnectionString();
+                    options.InstanceName = "portfolio-management-test";
+                });
+                services.AddHybridCache(options => options.DefaultEntryOptions = new HybridCacheEntryOptions
+                {
+                    LocalCacheExpiration = TimeSpan.FromMinutes(5),
+                    Expiration = TimeSpan.FromMinutes(5)
+                });
+                #endregion
+
+                services.RemoveAll<IMarketDataService>();
+                services.AddScoped(x => MarketDataServiceMock);
             });
-        });
 
         base.ConfigureWebHost(builder);
     }
-
-    public Portfolio FakePortfolio { get; private set; } = default!;
-
-    private async Task SeedDatabase(ApplicationDbContext dbContext)
+    private async Task SeedDatabaseAsync(ApplicationDbContext dbContext)
     {
-        FakePortfolio = new PortfolioBuilder().Build();
-        dbContext.Portfolios.Add(FakePortfolio);
+        PortfolioMock = new PortfolioBuilder().Build();
+        await dbContext.Portfolios.AddAsync(PortfolioMock);
         await dbContext.SaveChangesAsync();
     }
 
     public async Task InitializeAsync()
     {
         await _dbContainer.StartAsync();
+        await _redisContainer.StartAsync();
 
         using var scope = Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         if ((await dbContext.Database.GetPendingMigrationsAsync()).Any())
         {
             await dbContext.Database.MigrateAsync();
-            await SeedDatabase(dbContext);
+            await SeedDatabaseAsync(dbContext);
         }
     }
 
     async Task IAsyncLifetime.DisposeAsync()
     {
         await _dbContainer.StopAsync();
+        await _redisContainer.StopAsync();
     }
 }

--- a/src/contexts/portfolio-management/test/FinnHub.PortfolioManagement.WebApi.Tests/FinnHub.PortfolioManagement.WebApi.Tests.csproj
+++ b/src/contexts/portfolio-management/test/FinnHub.PortfolioManagement.WebApi.Tests/FinnHub.PortfolioManagement.WebApi.Tests.csproj
@@ -15,8 +15,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.6.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Updated `docker-compose.yaml` to include health checks for PostgreSQL, MongoDB, and Redis, and added a new Redis service.
- Enhanced `CreateAssetEndpoint.cs` to produce a 400 Bad Request response and tagged it with "Assets".
- Introduced `GetLatestPriceEndpoint` for retrieving current asset prices with appropriate response handling.
- Created `EndpointTags.cs` for defining constants for endpoint tags.
- Modified solution file to include a new project for "FinnHub.PortfolioManagement.Infrastructure.Integrations".
- Added `IMarketDataService` and `ITokenService` interfaces for market data fetching and token generation.
- Updated `RegisterBuyAssetHandler.cs` to call `IMarketDataService` for current market value during buy transactions.
- Implemented `TokenService.cs` for token generation and caching using `ICacheService`.
- Registered new services in `DependencyInjectionConfiguration.cs`.
- Created `MarketDataService.cs` to fetch market values from an external API using Flurl.
- Updated `appsettings.Development.json` and `appsettings.Test.json` for caching and market data settings.
- Enhanced `WebApiFactory.cs` to include Redis container setup for testing.
- Updated `PortfolioControllerTests.cs` to use mocks for market data service interactions.
- Updated test project file to include NSubstitute and Testcontainers for improved testing capabilities.