### PR TITLE
feat(portfolio): enhance market data and portfolio queries

### DIFF
--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/MarketData/IMarketDataService.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/MarketData/IMarketDataService.cs
@@ -1,5 +1,8 @@
-﻿namespace FinnHub.PortfolioManagement.Application.Abstractions.MarketData;
+﻿using FinnHub.Shared.Core;
+
+namespace FinnHub.PortfolioManagement.Application.Abstractions.MarketData;
+
 public interface IMarketDataService
 {
-    Task<decimal> GetCurrentMarketValueAsync(string assetSymbol, CancellationToken cancellationToken);
+    Task<Result<decimal>> GetCurrentMarketValueAsync(string assetSymbol, CancellationToken cancellationToken);
 }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/Queries/IPortfolioQueries.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/Queries/IPortfolioQueries.cs
@@ -1,0 +1,13 @@
+﻿using FinnHub.PortfolioManagement.Application.DTOs;
+using FinnHub.Shared.Core;
+
+namespace FinnHub.PortfolioManagement.Application.Abstractions.Queries;
+
+public interface IPortfolioQueries
+{
+    Task<PaginatedResult<PortfolioSummaryResponseDto>> GetPortfoliosSummaryAsync(
+        Guid userId,
+        PaginatedParams paginatedParams,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Commands/RegisterBuyAsset/RegisterBuyAssetHandler.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Commands/RegisterBuyAsset/RegisterBuyAssetHandler.cs
@@ -28,13 +28,17 @@ internal sealed class RegisterBuyAssetHandler(
         if (portfolio is null)
             return Result.Failure<RegisterBuyAssetResponse>(PortfolioErrors.PortfolioNotFound);
 
-        var currentMarketValue = await marketDataService.GetCurrentMarketValueAsync(request.AssetSymbol, cancellationToken);
+        var currentMarketValueResult = await marketDataService
+            .GetCurrentMarketValueAsync(request.AssetSymbol, cancellationToken);
+
+        if (currentMarketValueResult.IsFailure)
+            return Result.Failure<RegisterBuyAssetResponse>(currentMarketValueResult.Error);
 
         var transaction = portfolio.BuyAsset(
               request.AssetSymbol,
               request.Quantity,
               request.PricePerUnit,
-              currentMarketValue,
+              currentMarketValueResult.Value,
               request.TransactionDate
         );
 

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/DTOs/PortfolioSummaryResponseDto.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/DTOs/PortfolioSummaryResponseDto.cs
@@ -1,0 +1,11 @@
+﻿namespace FinnHub.PortfolioManagement.Application.DTOs;
+
+public sealed record PortfolioSummaryResponseDto(
+    Guid Id,
+    string Name,
+    string? Description,
+    DateTime CreationDate,
+    decimal TotalValue,
+    decimal TotalProfit
+);
+

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/FinnHub.PortfolioManagement.Application.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/FinnHub.PortfolioManagement.Application.csproj
@@ -21,4 +21,8 @@
     <InternalsVisibleTo Include="FinnHub.PortfolioManagement.Application.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Abstractions\DataAccess\" />
+  </ItemGroup>
+
 </Project>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetPortfoliosSummaryList/GetPortfoliosSummaryListQuery.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetPortfoliosSummaryList/GetPortfoliosSummaryListQuery.cs
@@ -1,0 +1,26 @@
+﻿using FinnHub.PortfolioManagement.Application.Abstractions.Queries;
+using FinnHub.PortfolioManagement.Application.Abstractions.Users;
+using FinnHub.Shared.Core;
+
+using MediatR;
+
+namespace FinnHub.PortfolioManagement.Application.Queries.GetPortfoliosSummaryList;
+
+internal sealed class GetPortfoliosSummaryListQuery(
+    IPortfolioQueries portfolioQueries,
+    IUserContext userContext
+) : IRequestHandler<GetPortfoliosSummaryListRequest, Result<GetPortfoliosSummaryListResponse>>
+{
+    public async Task<Result<GetPortfoliosSummaryListResponse>> Handle(GetPortfoliosSummaryListRequest request, CancellationToken cancellationToken)
+    {
+
+
+        var paginatedParams = new PaginatedParams
+        {
+            PageNumber = request.PageNumber,
+            PageSize = request.PageSize
+        };
+        var response = await portfolioQueries.GetPortfoliosSummaryAsync(userContext.UserId, paginatedParams, cancellationToken);
+        return new GetPortfoliosSummaryListResponse(response);
+    }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetPortfoliosSummaryList/GetPortfoliosSummaryListRequest.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetPortfoliosSummaryList/GetPortfoliosSummaryListRequest.cs
@@ -1,0 +1,11 @@
+﻿using FinnHub.Shared.Core;
+
+using MediatR;
+
+namespace FinnHub.PortfolioManagement.Application.Queries.GetPortfoliosSummaryList;
+
+public sealed record GetPortfoliosSummaryListRequest : IRequest<Result<GetPortfoliosSummaryListResponse>>
+{
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 10;
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetPortfoliosSummaryList/GetPortfoliosSummaryListResponse.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetPortfoliosSummaryList/GetPortfoliosSummaryListResponse.cs
@@ -1,0 +1,21 @@
+﻿using FinnHub.PortfolioManagement.Application.DTOs;
+using FinnHub.Shared.Core;
+
+namespace FinnHub.PortfolioManagement.Application.Queries.GetPortfoliosSummaryList;
+
+public sealed record GetPortfoliosSummaryListResponse : PaginatedResult<PortfolioSummaryResponseDto>
+{
+    public GetPortfoliosSummaryListResponse(PaginatedResult<PortfolioSummaryResponseDto> original) : base(original)
+    {
+    }
+
+    public GetPortfoliosSummaryListResponse(
+        int pageNumber,
+        int pageSize,
+        int totalCount,
+        IEnumerable<PortfolioSummaryResponseDto> items
+    ) : base(pageNumber, pageSize, totalCount, items)
+    {
+    }
+};
+

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/FinnHub.PortfolioManagement.Infrastructure.Integrations.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/FinnHub.PortfolioManagement.Infrastructure.Integrations.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Flurl" Version="4.0.0" />
     <PackageReference Include="Flurl.Http" Version="4.0.2" />
+    <PackageReference Include="Polly" Version="8.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Shared/Policies/PolicyFactory.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Integrations/Shared/Policies/PolicyFactory.cs
@@ -1,0 +1,44 @@
+﻿using FinnHub.Shared.Core;
+
+using Flurl.Http;
+
+using Polly;
+using Polly.Fallback;
+using Polly.Retry;
+
+namespace FinnHub.PortfolioManagement.Infrastructure.Integrations.Shared.Policies;
+
+internal static class PolicyFactory
+{
+    public static IAsyncPolicy<Result<T>> CreateDefaultPolicy<T>()
+    {
+        return new ResiliencePipelineBuilder<Result<T>>()
+            .AddRetry(new RetryStrategyOptions<Result<T>>
+            {
+                BackoffType = DelayBackoffType.Exponential,
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.FromSeconds(2),
+                ShouldHandle = new PredicateBuilder<Result<T>>()
+                    .Handle<FlurlHttpException>(IsTransient),
+            })
+            .AddFallback(new FallbackStrategyOptions<Result<T>>
+            {
+                ShouldHandle = new PredicateBuilder<Result<T>>()
+                    .Handle<FlurlHttpException>(IsTransient),
+                FallbackAction = async args =>
+                {
+                    var exception = args.Outcome.Exception as FlurlHttpException;
+                    var errorMessage = exception?.Message ?? "Unknown error.";
+                    var result = Result.Failure<T>(Error.Failure("Integration.Error", errorMessage));
+                    return await Outcome.FromResultAsValueTask(result);
+                }
+            })
+            .Build()
+            .AsAsyncPolicy();
+    }
+
+    private static bool IsTransient(FlurlHttpException ex)
+        => ex.Call?.Response == null
+            || ex.Call.Response.StatusCode >= 500
+            || ex.InnerException is TimeoutException;
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/FinnHub.PortfolioManagement.Infrastructure.Persistence.csproj
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/FinnHub.PortfolioManagement.Infrastructure.Persistence.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
     <PackageReference Include="FinnHub.Shared.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.6" />

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Queries/PortfolioQueries.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Queries/PortfolioQueries.cs
@@ -1,0 +1,53 @@
+﻿using Dapper;
+
+using FinnHub.PortfolioManagement.Application.Abstractions.Queries;
+using FinnHub.PortfolioManagement.Application.DTOs;
+using FinnHub.PortfolioManagement.Infrastructure.Persistence.Context;
+using FinnHub.Shared.Core;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace FinnHub.PortfolioManagement.Infrastructure.Persistence.Queries;
+
+internal class PortfolioQueries(ApplicationDbContext dbContext) : IPortfolioQueries
+{
+    public async Task<PaginatedResult<PortfolioSummaryResponseDto>> GetPortfoliosSummaryAsync(Guid userId, PaginatedParams paginatedParams, CancellationToken cancellationToken = default)
+    {
+        var offset = (paginatedParams.PageNumber - 1) * paginatedParams.PageSize;
+
+        var total = await dbContext.Portfolios
+            .CountAsync(p => p.UserId == userId, cancellationToken);
+
+        const string sql =
+            """
+            SELECT
+                p.id AS Id,
+                p.name AS Name,
+                p.description AS Description,
+                p.creation_date AS CreationDate,
+                COALESCE(SUM(pp.current_market_price_value), 0) AS TotalValue,
+                COALESCE(SUM(pp.current_market_price_value - pp.average_cost_value), 0) AS TotalProfit
+            FROM portfolios p
+            LEFT JOIN positions pp ON pp.portfolio_id = p.id
+            WHERE p.user_id = @UserId
+            GROUP BY p.id, p.name, p.description, p.creation_date
+            ORDER BY p.creation_date DESC
+            LIMIT @PageSize OFFSET @Offset;
+            """;
+
+        using var connection = dbContext.Database.GetDbConnection();
+        var result = await connection.QueryAsync<PortfolioSummaryResponseDto>(sql, new
+        {
+            UserId = userId,
+            Offset = offset,
+            paginatedParams.PageSize
+        });
+
+        return new PaginatedResult<PortfolioSummaryResponseDto>(
+            paginatedParams.PageNumber,
+            paginatedParams.PageSize,
+            total,
+            result
+        );
+    }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Setup/DependencyInjectionConfiguration.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Setup/DependencyInjectionConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿using FinnHub.PortfolioManagement.Application.Abstractions;
+using FinnHub.PortfolioManagement.Application.Abstractions.Queries;
 using FinnHub.PortfolioManagement.Domain.Aggregates.Repositories;
 using FinnHub.PortfolioManagement.Infrastructure.Persistence.Context;
+using FinnHub.PortfolioManagement.Infrastructure.Persistence.Queries;
 using FinnHub.PortfolioManagement.Infrastructure.Persistence.Repositories;
 using FinnHub.PortfolioManagement.Infrastructure.Persistence.Settings;
 using FinnHub.PortfolioManagement.Infrastructure.Persistence.Shared;
@@ -28,6 +30,7 @@ public static class DependencyInjectionConfiguration
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IPortfolioRepository, PortfolioRepository>();
+        services.AddScoped<IPortfolioQueries, PortfolioQueries>();
 
         return services;
     }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Controllers/PortfolioController.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Controllers/PortfolioController.cs
@@ -3,6 +3,7 @@
 using FinnHub.PortfolioManagement.Application.Commands.CreatePortfolio;
 using FinnHub.PortfolioManagement.Application.Commands.RegisterBuyAsset;
 using FinnHub.PortfolioManagement.Application.Commands.RegisterSellAsset;
+using FinnHub.PortfolioManagement.Application.Queries.GetPortfoliosSummaryList;
 using FinnHub.PortfolioManagement.WebApi.Models;
 
 using MediatR;
@@ -63,6 +64,19 @@ public class PortfolioController(ISender sender) : ControllerBase
 
         return result.IsSuccess
             ? HandleResponse(result, HttpStatusCode.Created)
+            : HandleResponse(result);
+    }
+
+    [HttpGet("summary")]
+    [ProducesResponseType<GetPortfoliosSummaryListResponse>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPortfoliosSummaryList(
+        [FromQuery] GetPortfoliosSummaryListRequest query,
+        CancellationToken cancellationToken
+    )
+    {
+        var result = await sender.Send(query, cancellationToken);
+        return result.IsSuccess
+            ? HandleResponse(result, HttpStatusCode.OK)
             : HandleResponse(result);
     }
 }


### PR DESCRIPTION
- Modify `IMarketDataService` to return `Result<decimal>` for improved error handling.
- Introduce `IPortfolioQueries` interface with `GetPortfoliosSummaryAsync` method.
- Update `RegisterBuyAssetHandler` to handle new return type from market data service.
- Add `PortfolioSummaryResponseDto` record for portfolio summary representation.
- Update project file to include a new folder for data access abstractions.
- Create `GetPortfoliosSummaryListQuery` class for handling portfolio summary requests.
- Introduce `GetPortfoliosSummaryListRequest` record for pagination parameters.
- Add `GetPortfoliosSummaryListResponse` record extending `PaginatedResult<PortfolioSummaryResponseDto>`.
- Update infrastructure project file to include `Polly` for resilience in API calls.
- Enhance `MarketDataService` with resilience policies using `Polly`.
- Introduce `PolicyFactory` class for creating resilience policies for API calls.
- Update infrastructure persistence project file to include `Dapper` for data access.
- Implement `PortfolioQueries` class for retrieving portfolio summaries using Dapper.
- Update `DependencyInjectionConfiguration` to register `IPortfolioQueries` service.
- Add new endpoint in `PortfolioController` for retrieving portfolio summaries.