### PR TITLE
feat(portfolio): add transaction retrieval and pagination

### DIFF
--- a/src/building-blocks/FinnHub.Shared.Core/FinnHub.Shared.Core.csproj
+++ b/src/building-blocks/FinnHub.Shared.Core/FinnHub.Shared.Core.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>FinnHub.Shared.Core</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Rafael Freitas</Authors>
     <Company>FinnHub</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/building-blocks/FinnHub.Shared.Core/PaginatedParams.cs
+++ b/src/building-blocks/FinnHub.Shared.Core/PaginatedParams.cs
@@ -2,6 +2,12 @@
 
 public sealed record PaginatedParams
 {
-    public required int PageNumber { get; init; }
-    public required int PageSize { get; init; }
+    public int PageNumber { get; init; } = 1;
+    public int PageSize { get; init; } = 10;
+
+    public PaginatedParams(int pageNumber, int pageSize)
+    {
+        PageNumber = pageNumber;
+        PageSize = pageSize;
+    }
 }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/Queries/IPortfolioQueries.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Abstractions/Queries/IPortfolioQueries.cs
@@ -10,4 +10,11 @@ public interface IPortfolioQueries
         PaginatedParams paginatedParams,
         CancellationToken cancellationToken = default
     );
+
+    Task<PaginatedResult<PortfolioTransactionsResponseDto>> GetTransactionsAsync(
+        Guid userId,
+        Guid portfolioId,
+        PaginatedParams paginatedParams,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/DTOs/PortfolioTransactionsResponseDto.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/DTOs/PortfolioTransactionsResponseDto.cs
@@ -1,0 +1,17 @@
+﻿namespace FinnHub.PortfolioManagement.Application.DTOs;
+
+public sealed class PortfolioTransactionsResponseDto
+{
+    public Guid Id { get; init; }
+    public Guid PortfolioId { get; init; }
+    public string AssetSymbol { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public int Quantity { get; init; }
+    public decimal Price { get; init; }
+    public decimal TotalAmount { get; init; }
+    public decimal CurrentMarketValue { get; init; }
+    public DateTime TransactionDate { get; init; }
+    public bool IsSettled { get; init; }
+    public decimal? ProfitLoss { get; init; }
+    public decimal? ProfitLossPercentage { get; init; }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetTransactionsList/GetTransactionsListHandler.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetTransactionsList/GetTransactionsListHandler.cs
@@ -1,0 +1,30 @@
+﻿using FinnHub.PortfolioManagement.Application.Abstractions.Queries;
+using FinnHub.PortfolioManagement.Application.Abstractions.Users;
+using FinnHub.Shared.Core;
+
+using MediatR;
+
+namespace FinnHub.PortfolioManagement.Application.Queries.GetTransactionsList;
+internal sealed class GetTransactionsListHandler(
+    IPortfolioQueries portfolioQueries,
+    IUserContext userContext
+) : IRequestHandler<GetTransactionsListRequest, Result<GetTransactionsListResponse>>
+{
+    public async Task<Result<GetTransactionsListResponse>> Handle(GetTransactionsListRequest request, CancellationToken cancellationToken)
+    {
+        // TODO: Implement PaginatedParams
+        var paginatedParams = new PaginatedParams
+        {
+            PageNumber = request.PageNumber == 0 ? 1 : request.PageNumber,
+            PageSize = request.PageSize == 0 ? 10 : request.PageSize
+        };
+
+        var result = await portfolioQueries.GetTransactionsAsync(
+            userContext.UserId,
+            request.PortfolioId,
+            paginatedParams,
+            cancellationToken);
+
+        return new GetTransactionsListResponse(result);
+    }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetTransactionsList/GetTransactionsListRequest.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetTransactionsList/GetTransactionsListRequest.cs
@@ -1,0 +1,12 @@
+﻿using FinnHub.Shared.Core;
+
+using MediatR;
+
+namespace FinnHub.PortfolioManagement.Application.Queries.GetTransactionsList;
+
+public sealed record GetTransactionsListRequest : IRequest<Result<GetTransactionsListResponse>>
+{
+    public Guid PortfolioId { get; set; }
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 10;
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetTransactionsList/GetTransactionsListResponse.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Application/Queries/GetTransactionsList/GetTransactionsListResponse.cs
@@ -1,0 +1,23 @@
+﻿
+using FinnHub.PortfolioManagement.Application.DTOs;
+using FinnHub.Shared.Core;
+
+namespace FinnHub.PortfolioManagement.Application.Queries.GetTransactionsList;
+
+public sealed record GetTransactionsListResponse : PaginatedResult<PortfolioTransactionsResponseDto>
+{
+    public GetTransactionsListResponse(
+        PaginatedResult<PortfolioTransactionsResponseDto> original
+    ) : base(original)
+    {
+    }
+
+    public GetTransactionsListResponse(
+        int pageNumber,
+        int pageSize,
+        int totalCount,
+        IEnumerable<PortfolioTransactionsResponseDto> items
+    ) : base(pageNumber, pageSize, totalCount, items)
+    {
+    }
+}

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Queries/PortfolioQueries.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.Infrastructure.Persistence/Queries/PortfolioQueries.cs
@@ -50,4 +50,77 @@ internal class PortfolioQueries(ApplicationDbContext dbContext) : IPortfolioQuer
             result
         );
     }
+
+    public async Task<PaginatedResult<PortfolioTransactionsResponseDto>> GetTransactionsAsync(Guid userId, Guid portfolioId, PaginatedParams paginatedParams, CancellationToken cancellationToken = default)
+    {
+        var offset = (paginatedParams.PageNumber - 1) * paginatedParams.PageSize;
+
+        var portfolioExists = await dbContext.Portfolios
+            .AnyAsync(p => p.Id == portfolioId && p.UserId == userId, cancellationToken);
+
+        if (!portfolioExists)
+            return new PaginatedResult<PortfolioTransactionsResponseDto>(
+                paginatedParams.PageNumber,
+                paginatedParams.PageSize,
+                0,
+                []
+            );
+
+        const string countSql =
+        """
+        SELECT COUNT(*) 
+        FROM transactions t
+        INNER JOIN portfolios p ON p.id = t.portfolio_id
+        WHERE t.portfolio_id = @PortfolioId AND p.user_id = @UserId
+        """;
+
+        const string transactionsSql =
+        """
+        SELECT
+            t.id AS Id,
+            t.portfolio_id AS PortfolioId,
+            t.asset_symbol AS AssetSymbol,
+            t.type AS Type,
+            t.quantity AS Quantity,
+            t.price_value AS Price,
+            (t.price_value * t.quantity) AS TotalAmount,
+            t.current_market_value_value AS CurrentMarketValue,
+            t.transaction_date AS TransactionDate,
+            t.is_settled AS IsSettled,
+            CASE 
+                WHEN t.type = 'Buy' AND t.current_market_value_value IS NOT NULL 
+                THEN (t.current_market_value_value - (t.price_value * t.quantity))
+                ELSE NULL 
+            END AS ProfitLoss,
+            CASE 
+                WHEN t.type = 'Buy' AND t.current_market_value_value IS NOT NULL AND (t.price_value * t.quantity) > 0
+                THEN ((t.current_market_value_value - (t.price_value * t.quantity)) / (t.price_value * t.quantity) * 100)
+                ELSE NULL 
+            END AS ProfitLossPercentage
+        FROM transactions t
+        INNER JOIN portfolios p ON p.id = t.portfolio_id
+        WHERE t.portfolio_id = @PortfolioId AND p.user_id = @UserId
+        ORDER BY t.transaction_date DESC
+        LIMIT @PageSize OFFSET @Offset
+        """;
+
+        var parameters = new
+        {
+            PortfolioId = portfolioId,
+            UserId = userId,
+            Offset = offset,
+            paginatedParams.PageSize
+        };
+
+        using var connection = dbContext.Database.GetDbConnection();
+        var totalCount = await connection.QuerySingleAsync<int>(countSql, parameters);
+        var transactions = await connection.QueryAsync<PortfolioTransactionsResponseDto>(transactionsSql, parameters);
+
+        return new PaginatedResult<PortfolioTransactionsResponseDto>(
+            paginatedParams.PageNumber,
+            paginatedParams.PageSize,
+            totalCount,
+            [.. transactions]
+        );
+    }
 }

--- a/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Controllers/PortfolioController.cs
+++ b/src/contexts/portfolio-management/src/FinnHub.PortfolioManagement.WebApi/Controllers/PortfolioController.cs
@@ -5,7 +5,9 @@ using FinnHub.PortfolioManagement.Application.Commands.RegisterBuyAsset;
 using FinnHub.PortfolioManagement.Application.Commands.RegisterSellAsset;
 using FinnHub.PortfolioManagement.Application.Queries.GetPortfolioDetails;
 using FinnHub.PortfolioManagement.Application.Queries.GetPortfoliosSummaryList;
+using FinnHub.PortfolioManagement.Application.Queries.GetTransactionsList;
 using FinnHub.PortfolioManagement.WebApi.Models;
+using FinnHub.Shared.Core;
 
 using MediatR;
 
@@ -44,6 +46,28 @@ public class PortfolioController(ISender sender) : ControllerBase
     )
     {
         var request = new GetPortfolioDetailsRequest { Id = id };
+
+        var result = await sender.Send(request, cancellationToken);
+
+        return result.IsSuccess
+            ? HandleResponse(result, HttpStatusCode.OK)
+            : HandleResponse(result);
+    }
+
+    [HttpGet("{id:guid}/transactions")]
+    [ProducesResponseType<GetTransactionsListResponse>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPortfolioTransactions(
+       [FromRoute] Guid id,
+       [FromQuery] PaginatedParams paginatedParams,
+       CancellationToken cancellationToken
+    )
+    {
+        var request = new GetTransactionsListRequest
+        {
+            PortfolioId = id,
+            PageNumber = paginatedParams.PageNumber,
+            PageSize = paginatedParams.PageSize
+        };
 
         var result = await sender.Send(request, cancellationToken);
 


### PR DESCRIPTION
- Update FinnHub.Shared.Core package version to 1.0.1.
- Modify `PaginatedParams` to include default values and a constructor.
- Add `GetTransactionsAsync` method to `IPortfolioQueries` interface.
- Create `PortfolioTransactionsResponseDto` for transaction details.
- Update `GetTransactionsListHandler` to implement pagination.
- Introduce `GetTransactionsListRequest` for transaction request parameters.
- Create `GetTransactionsListResponse` extending `PaginatedResult`.
- Update `PortfolioQueries` to support transaction retrieval with pagination.
- Add new endpoint in `PortfolioController` for fetching portfolio transactions.