### PR TITLE
fix(docker): simplify project file paths in Dockerfile

### DIFF
--- a/src/contexts/market-data/src/FinnHub.MarketData.Ingestion/Dockerfile
+++ b/src/contexts/market-data/src/FinnHub.MarketData.Ingestion/Dockerfile
@@ -5,12 +5,16 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["src/FinnHub.MarketData.Ingestion/FinnHub.MarketData.Ingestion.csproj", "src/FinnHub.MarketData.Ingestion/"]
-COPY ["src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj", "src/FinnHub.MarketData.WebApi/"]
-COPY ["src/FinnHub.MarketData.Shared/FinnHub.MarketData.Shared.csproj", "src/FinnHub.MarketData.Shared/"]
+
+COPY ["src/FinnHub.MarketData.Ingestion/FinnHub.MarketData.Ingestion.csproj", "FinnHub.MarketData.Ingestion/"]
+COPY ["src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj", "FinnHub.MarketData.WebApi/"]
+COPY ["src/FinnHub.MarketData.Shared/FinnHub.MarketData.Shared.csproj", "FinnHub.MarketData.Shared/"]
+
 RUN dotnet restore "./src/FinnHub.MarketData.Ingestion/FinnHub.MarketData.Ingestion.csproj"
-COPY . .
-WORKDIR "/src/src/FinnHub.MarketData.Ingestion"
+
+COPY ["src/", "."]
+
+WORKDIR "/src/FinnHub.MarketData.Ingestion"
 RUN dotnet build "./FinnHub.MarketData.Ingestion.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish

--- a/src/contexts/market-data/src/FinnHub.MarketData.Processor/Dockerfile
+++ b/src/contexts/market-data/src/FinnHub.MarketData.Processor/Dockerfile
@@ -5,12 +5,16 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["src/FinnHub.MarketData.Processor/FinnHub.MarketData.Processor.csproj", "src/FinnHub.MarketData.Processor/"]
-COPY ["src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj", "src/FinnHub.MarketData.WebApi/"]
-COPY ["src/FinnHub.MarketData.Shared/FinnHub.MarketData.Shared.csproj", "src/FinnHub.MarketData.Shared/"]
-RUN dotnet restore "./src/FinnHub.MarketData.Processor/FinnHub.MarketData.Processor.csproj"
-COPY . .
-WORKDIR "/src/src/FinnHub.MarketData.Processor"
+
+COPY ["src/FinnHub.MarketData.Processor/FinnHub.MarketData.Processor.csproj", "FinnHub.MarketData.Processor/"]
+COPY ["src/FinnHub.MarketData.WebApi/FinnHub.MarketData.WebApi.csproj", "FinnHub.MarketData.WebApi/"]
+COPY ["src/FinnHub.MarketData.Shared/FinnHub.MarketData.Shared.csproj", "FinnHub.MarketData.Shared/"]
+
+RUN dotnet restore "FinnHub.MarketData.Processor/FinnHub.MarketData.Processor.csproj"
+
+COPY ["src/", "."]
+
+WORKDIR "/src/FinnHub.MarketData.Processor"
 RUN dotnet build "./FinnHub.MarketData.Processor.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish


### PR DESCRIPTION
- Updated COPY commands to remove leading "src/" from paths.
- Adjusted RUN dotnet restore command to match new paths.
- Modified working directory to ensure correct build process.